### PR TITLE
Remove references to NSColor in iOS/NIKFontAwesomeImageView

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ xcuserdata
 
 Podfile.lock
 Pods
+
+build

--- a/FontAwesomeIconFactory/iOS/NIKFontAwesomeImageView.m
+++ b/FontAwesomeIconFactory/iOS/NIKFontAwesomeImageView.m
@@ -163,11 +163,11 @@
     self.edgeInsets = edgeInsets;
 }
 
-- (GENERIC(NSArray, NSColor *) *)colors {
+- (GENERIC(NSArray, UIColor *) *)colors {
     return self.factory.colors;
 }
 
-- (void)setColors:(GENERIC(NSArray, NSColor *) *)colors {
+- (void)setColors:(GENERIC(NSArray, UIColor *) *)colors {
     self.factory.colors = [colors copy];
     [self setNeedsUpdateImage];
 }

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source 'https://rubygems.org'
+
+gem 'cocoapods', '0.38.2'
+

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
 
 gem 'cocoapods', '0.38.2'
+gem 'xcpretty', '>= 0.1.11', '< 1.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,62 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (4.2.4)
+      i18n (~> 0.7)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.3, >= 0.3.4)
+      tzinfo (~> 1.1)
+    claide (0.9.1)
+    cocoapods (0.38.2)
+      activesupport (>= 3.2.15)
+      claide (~> 0.9.1)
+      cocoapods-core (= 0.38.2)
+      cocoapods-downloader (~> 0.9.1)
+      cocoapods-plugins (~> 0.4.2)
+      cocoapods-stats (~> 0.5.3)
+      cocoapods-trunk (~> 0.6.1)
+      cocoapods-try (~> 0.4.5)
+      colored (~> 1.2)
+      escape (~> 0.0.4)
+      molinillo (~> 0.3.1)
+      nap (~> 0.8)
+      xcodeproj (~> 0.26.3)
+    cocoapods-core (0.38.2)
+      activesupport (>= 3.2.15)
+      fuzzy_match (~> 2.0.4)
+      nap (~> 0.8.0)
+    cocoapods-downloader (0.9.3)
+    cocoapods-plugins (0.4.2)
+      nap
+    cocoapods-stats (0.5.3)
+      nap (~> 0.8)
+    cocoapods-trunk (0.6.4)
+      nap (>= 0.8, < 2.0)
+      netrc (= 0.7.8)
+    cocoapods-try (0.4.5)
+    colored (1.2)
+    escape (0.0.4)
+    fuzzy_match (2.0.4)
+    i18n (0.7.0)
+    json (1.8.3)
+    minitest (5.8.0)
+    molinillo (0.3.1)
+    nap (0.8.0)
+    netrc (0.7.8)
+    thread_safe (0.3.5)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
+    xcodeproj (0.26.3)
+      activesupport (>= 3)
+      claide (~> 0.9.1)
+      colored (~> 1.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  cocoapods (= 0.38.2)
+
+BUNDLED WITH
+   1.10.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,12 +51,14 @@ GEM
       activesupport (>= 3)
       claide (~> 0.9.1)
       colored (~> 1.2)
+    xcpretty (0.1.11)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   cocoapods (= 0.38.2)
+  xcpretty (>= 0.1.11, < 1.0)
 
 BUNDLED WITH
    1.10.6

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+all:
+	$(MAKE) clean
+	$(MAKE) xct
+
+clean:
+	rm -rf build
+
+xct:
+	bin/make/xctest.sh
+

--- a/bin/make/xctest.sh
+++ b/bin/make/xctest.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+bundle
+bundle exec pod install
+
+xcrun xcodebuild \
+  clean \
+  test \
+  -SYMROOT=build \
+  -derivedDataPath build \
+  -workspace FontAwesomeIconFactory.xcworkspace \
+  -scheme FontAwesomeIconFactory \
+  -destination 'platform=iOS Simulator,name=iPhone 5s,OS=latest' \
+  -sdk iphonesimulator \
+  -configuration Debug \
+  | bundle exec xcpretty -tc && exit ${PIPESTATUS[0]}
+


### PR DESCRIPTION
### Motivation

I don't actually expect this to be merged.  I added a bunch of files so I could demonstrate the problem.

I am working on another repo that uses FontAwesomeIconFactory with CocoaPods.  I am trying to get that repo's Xcode project to build on the command line (to integrate with CI).

References to `NSColor` in iOS/NIKFontAwesomeImageView.m are causing command line builds to fail.

I have no idea why running the XCTests from Xcode does not reproduce the problem.  I even tried importing iOS/NIKFontAwesomeImageView into `FontAwesomeIconFactoryTests.m` - the tests still passed in Xcode.

The problem is pretty clear: the NSColor references need to be replaced.

Whether or not this should be merged as-is is, I don't know.

### Reproduce

If you are installing gems with `sudo`, don't try to reproduce. Using bundler + sudo is recipe for disaster.

```
1. Get a local copy of this PR.
2. $ bundle install
3. $ make xct 
```

### Expected

The unit tests to pass.

### Found

```
⌦  /Users/moody/tmp/FontAwesomeIconFactory/FontAwesomeIconFactory/iOS/NIKFontAwesomeImageView.m:166:21: unknown type name 'NSColor'

- (GENERIC(NSArray, NSColor *) *)colors {
                    ^
⌦  /Users/moody/tmp/FontAwesomeIconFactory/FontAwesomeIconFactory/iOS/NIKFontAwesomeImageView.m:170:37: unknown type name 'NSColor'

- (void)setColors:(GENERIC(NSArray, NSColor *) *)colors {
                                          ^


Testing failed:
        Unknown type name 'NSColor'
        Unknown type name 'NSColor'
```